### PR TITLE
If the server has a locking exception we should retry

### DIFF
--- a/src/main/java/io/tus/java/client/ProtocolException.java
+++ b/src/main/java/io/tus/java/client/ProtocolException.java
@@ -31,7 +31,7 @@ public class ProtocolException extends Exception {
         try {
             int responseCode = connection.getResponseCode();
 
-            return responseCode >= 500 && responseCode < 600;
+            return responseCode >= 500 && responseCode < 600 || responseCode == 423;
         } catch(IOException e) {
             return false;
         }

--- a/src/main/java/io/tus/java/client/TusClient.java
+++ b/src/main/java/io/tus/java/client/TusClient.java
@@ -107,12 +107,12 @@ public class TusClient {
 
         int responseCode = connection.getResponseCode();
         if(!(responseCode >= 200 && responseCode < 300)) {
-            throw new ProtocolException("unexpected status code (" + responseCode + ") while creating upload");
+            throw new ProtocolException("unexpected status code (" + responseCode + ") while creating upload", connection);
         }
 
         String urlStr = connection.getHeaderField("Location");
         if(urlStr.length() == 0) {
-            throw new ProtocolException("missing upload URL in response for creating upload");
+            throw new ProtocolException("missing upload URL in response for creating upload", connection);
         }
 
         URL uploadURL = new URL(urlStr);
@@ -159,12 +159,12 @@ public class TusClient {
 
         int responseCode = connection.getResponseCode();
         if(!(responseCode >= 200 && responseCode < 300)) {
-            throw new ProtocolException("unexpected status code (" + responseCode + ") while resuming upload");
+            throw new ProtocolException("unexpected status code (" + responseCode + ") while resuming upload", connection);
         }
 
         String offsetStr = connection.getHeaderField("Upload-Offset");
         if(offsetStr.length() == 0) {
-            throw new ProtocolException("missing upload offset in response for resuming upload");
+            throw new ProtocolException("missing upload offset in response for resuming upload", connection);
         }
         long offset = Long.parseLong(offsetStr);
 

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -192,7 +192,7 @@ public class TusUploader {
         connection.disconnect();
 
         if(!(responseCode >= 200 && responseCode < 300)) {
-            throw new io.tus.java.client.ProtocolException("unexpected status code (" + responseCode + ") while uploading chunk");
+            throw new io.tus.java.client.ProtocolException("unexpected status code (" + responseCode + ") while uploading chunk", connection);
         }
     }
 }


### PR DESCRIPTION
The client might have switched networks and the server not timed out on the incoming conneciton.