### PR TITLE
defer-length feature supported (issue #13)

### DIFF
--- a/example/src/main/java/io/tus/java/example/Main.java
+++ b/example/src/main/java/io/tus/java/example/Main.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import io.tus.java.client.ProtocolException;
 import io.tus.java.client.TusClient;
 import io.tus.java.client.TusExecutor;
+import io.tus.java.client.TusUploadLengthStoreImpl;
 import io.tus.java.client.TusURLMemoryStore;
 import io.tus.java.client.TusUpload;
 import io.tus.java.client.TusUploader;
@@ -29,6 +30,8 @@ public class Main {
 
             // Enable resumable uploads by storing the upload URL in memory
             client.enableResuming(new TusURLMemoryStore());
+            // Enable defer-length feature by storing the upload size in memory
+            client.enableDeferLength(new TusUploadLengthStoreImpl());
 
             // Open a file using which we will then create a TusUpload. If you do not have
             // a File object, you can manually construct a TusUpload using an InputStream.

--- a/src/main/java/io/tus/java/client/TusUpload.java
+++ b/src/main/java/io/tus/java/client/TusUpload.java
@@ -12,8 +12,7 @@ import java.util.Map;
 /**
  * This class contains information about a file which will be uploaded later. Uploading is not
  * done using this class but using {@link TusUploader} whose instances are returned by
- * {@link TusClient#createUpload(TusUpload)}, {@link TusClient#createUpload(TusUpload)} and
- * {@link TusClient#resumeOrCreateUpload(TusUpload)}.
+ * {@link TusClient#createUpload(TusUpload)} and {@link TusClient#resumeOrCreateUpload(TusUpload)}.
  */
 public class TusUpload {
     private long size;
@@ -21,6 +20,8 @@ public class TusUpload {
     private TusInputStream tusInputStream;
     private String fingerprint;
     private Map<String, String> metadata;
+    //this property becomes obsolete if the "size" property is an object allowing "null" value
+    private boolean sizeConfigured;
 
     /**
      * Create a new TusUpload object.
@@ -36,7 +37,7 @@ public class TusUpload {
      * @throws FileNotFoundException Thrown if the file cannot be found.
      */
     public TusUpload(@NotNull File file) throws FileNotFoundException {
-        size = file.length();
+        setSize(file.length());
         setInputStream(new FileInputStream(file));
 
         fingerprint = String.format("%s-%d", file.getAbsolutePath(), size);
@@ -55,7 +56,19 @@ public class TusUpload {
      * @param size File's size in bytes.
      */
     public void setSize(long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("The size must be a non-negative value!");
+        }
+        this.sizeConfigured = true;
         this.size = size;
+    }
+
+    /**
+     *
+     * @return <code>true</code> if the size of the upload is configured otherwise <code>false</code>
+     */
+    public boolean isSizeConfigured() {
+        return sizeConfigured;
     }
 
     public String getFingerprint() {
@@ -119,7 +132,7 @@ public class TusUpload {
     }
 
     /**
-     * Encode a byte-array using Base64. This is a sligtly modified version from an implementation
+     * Encode a byte-array using Base64. This is a slightly modified version from an implementation
      * published on Wikipedia (https://en.wikipedia.org/wiki/Base64#Sample_Implementation_in_Java)
      * under the Creative Commons Attribution-ShareAlike License.
      */

--- a/src/main/java/io/tus/java/client/TusUploadLengthStore.java
+++ b/src/main/java/io/tus/java/client/TusUploadLengthStore.java
@@ -1,0 +1,41 @@
+package io.tus.java.client;
+
+import java.net.URL;
+
+/**
+ * Implementations of this interface are used to map an upload's url with the corresponding
+ * total upload size. If there is an upload size for the url in the store, when the 'Upload-Length' header
+ * is already transmitted to the TUS server (and no further update must happen in order to be compliant with TUS protocol)
+ *
+ * This functionality is used to allow TUS's Upload-Defer-Length feature.
+ *
+ * @author rfelgentraeger
+ */
+public interface TusUploadLengthStore {
+    /**
+     * Store a new upload url and its total size in bytes.
+     *
+     * @param uploadUrl An upload's url.
+     * @param bytes The corresponding total size.
+     * @throws IllegalArgumentException if the upload url is already set or the value is negative
+     */
+    void set(URL uploadUrl, long bytes);
+
+    /**
+     * Retrieve an upload's size for an upload url. If no matching entry is found this method will
+     * return {@code null}.
+     *
+     * @param uploadUrl An upload's url.
+     * @return The corresponding total upload size in bytes or {@code null}> if not found
+     */
+    Long get(URL uploadUrl);
+
+    /**
+     * Remove an entry from the store. Calling {@link #get(String)} with the same url will
+     * return {@code null}. If no entry exists for this upload url no exception should be
+     * thrown.
+     *
+     * @param uploadUrl An upload's url.
+     */
+    void remove(URL uploadUrl);
+}

--- a/src/main/java/io/tus/java/client/TusUploadLengthStoreImpl.java
+++ b/src/main/java/io/tus/java/client/TusUploadLengthStoreImpl.java
@@ -1,0 +1,37 @@
+package io.tus.java.client;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The values will only be stored as long as the application is running. This store will not
+ * keep the values after your application crashes or restarts.
+ *
+ * @author rfelgentraeger
+ */
+public class TusUploadLengthStoreImpl implements TusUploadLengthStore {
+
+    private Map<URL, Long> store = new HashMap<URL, Long>();
+
+    @Override
+    public void set(URL uploadUrl, long bytes) {
+        if (store.containsKey(uploadUrl)) {
+            throw new IllegalArgumentException("upload size is immutable");
+        }
+        if (bytes < 0) {
+            throw new IllegalArgumentException("upload size must be a non-negative value");
+        }
+        store.put(uploadUrl, bytes);
+    }
+
+    @Override
+    public Long get(URL uploadUrl) {
+        return store.get(uploadUrl);
+    }
+
+    @Override
+    public void remove(URL uploadUrl) {
+        store.remove(uploadUrl);
+    }
+}

--- a/src/test/java/io/tus/java/client/TestTusClient.java
+++ b/src/test/java/io/tus/java/client/TestTusClient.java
@@ -149,7 +149,8 @@ public class TestTusClient extends MockServerProvider {
                 .respond(new HttpResponse()
                         .withStatusCode(204)
                         .withHeader("Tus-Resumable", TusClient.TUS_VERSION)
-                        .withHeader("Upload-Offset", "3"));
+                        .withHeader("Upload-Offset", "3")
+                        .withHeader("Upload-Length", Long.toString(10)));
 
         TusClient client = new TusClient();
         client.setUploadCreationURL(mockServerURL);


### PR DESCRIPTION
Hello @Acconut ,

this is my first version of the "upload-defer-length" feature of the TUS protocol spec. 
I implemented an "enableDefer" method for the defer-length feature like you did with the "enableResuming" method for resumable upload feature. 

This pull requests targets the issue #13 