### PR TITLE
Add a hook after connection is established

### DIFF
--- a/src/main/java/io/tus/java/client/TusClient.java
+++ b/src/main/java/io/tus/java/client/TusClient.java
@@ -156,6 +156,8 @@ public class TusClient {
             throw new ProtocolException("missing upload URL in response for creating upload", connection);
         }
 
+        onConnectionOpened(connection);
+
         // The upload URL must be relative to the URL of the request by which is was returned,
         // not the upload creation URL. In most cases, there is no difference between those two
         // but there may be cases in which the POST request is redirected.
@@ -167,6 +169,13 @@ public class TusClient {
 
         return new TusUploader(this, uploadURL, upload.getTusInputStream(), 0);
     }
+
+    /**
+     * Hook for subclasses to do any post-open tasks
+     *
+     * @param urlConnection
+     */
+    protected void onConnectionOpened(HttpURLConnection urlConnection) {}
 
     /**
      * Try to resume an already started upload. Before call this function, resuming must be
@@ -211,6 +220,8 @@ public class TusClient {
             throw new ProtocolException("missing upload offset in response for resuming upload", connection);
         }
         long offset = Long.parseLong(offsetStr);
+
+        onConnectionOpened(connection);
 
         return new TusUploader(this, uploadURL, upload.getTusInputStream(), offset);
     }


### PR DESCRIPTION
We encountered a problem using tus-java-client when server is behind the aws load balancer. For things to work correctly, we need to be able to read the `set-cookie` header and send it back on future requests.

This could be implemented directly in the client, but I wanted to make as few changes(and as low-impact as possible). So instead I opted to add a hook after connection is opened. In our usage code we subclass `TusClient` and override the newly added `onConnectionOpened` to retrieve the headers and `prepareConnection` to inject cookies later on.