### PR TITLE
Bypass CreationURL

### DIFF
--- a/src/main/java/io/tus/java/client/TusClient.java
+++ b/src/main/java/io/tus/java/client/TusClient.java
@@ -161,6 +161,9 @@ public class TusClient {
     public TusUploader createUpload(@NotNull TusUpload upload) throws ProtocolException, IOException {
 
         if (!useCreationExtension){
+            if(resumingEnabled) {
+                urlStore.set(upload.getFingerprint(), uploadLocationURL);
+            }
             return new TusUploader(this, uploadLocationURL, upload.getTusInputStream(), 0);
         }
         HttpURLConnection connection = (HttpURLConnection) uploadCreationURL.openConnection();


### PR DESCRIPTION
When using the TusClient with a location URL instead of a creation URL it throws a ProtocolException. In some cases a tus server doesn't (properly) implement the Creation Extension(like Vimeo). Instead you get the Location URL via a different way. I added the ability to directly use this URL instead of requiring a creation URL