### PR TITLE
Add support for removeFingerprintOnSuccess config property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile 'org.jetbrains:annotations:13.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mock-server:mockserver-netty:5.2.2'
+    testCompile 'org.mockito:mockito-core:2.+'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/main/java/io/tus/java/client/TusClient.java
+++ b/src/main/java/io/tus/java/client/TusClient.java
@@ -325,7 +325,7 @@ public class TusClient {
      * 
      * @param upload that has been finished
      */
-    public void uploadFinished(@NotNull TusUpload upload) {
+    protected void uploadFinished(@NotNull TusUpload upload) {
         if (resumingEnabled && removeFingerprintOnSuccessEnabled) {
             urlStore.remove(upload.getFingerprint());
         }

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -24,6 +24,7 @@ public class TusUploader {
     private TusInputStream input;
     private long offset;
     private TusClient client;
+    private TusUpload upload;
     private byte[] buffer;
     private int requestPayloadSize = 10 * 1024 * 1024;
     private int bytesRemainingForRequest;
@@ -41,11 +42,12 @@ public class TusUploader {
      * @param offset Offset to read from
      * @throws IOException Thrown if an exception occurs while issuing the HTTP request.
      */
-    public TusUploader(TusClient client, URL uploadURL, TusInputStream input, long offset) throws IOException {
+    public TusUploader(TusClient client, TusUpload upload, URL uploadURL, TusInputStream input, long offset) throws IOException {
         this.uploadURL = uploadURL;
         this.input = input;
         this.offset = offset;
         this.client = client;
+        this.upload = upload;
 
         input.seekTo(offset);
 
@@ -270,6 +272,10 @@ public class TusUploader {
      */
     public void finish() throws ProtocolException, IOException {
         finishConnection();
+        if (upload.getSize() == offset) {
+            client.uploadFinished(upload);    
+        }
+        
         // Close the TusInputStream after checking the response and closing the connection to ensure
         // that we will not need to read from it again in the future.
         input.close();

--- a/src/test/java/io/tus/java/client/TestTusClient.java
+++ b/src/test/java/io/tus/java/client/TestTusClient.java
@@ -1,5 +1,10 @@
 package io.tus.java.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -12,8 +17,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
-
-import static org.junit.Assert.*;
 
 
 public class TestTusClient extends MockServerProvider {
@@ -350,5 +353,48 @@ public class TestTusClient extends MockServerProvider {
         TusUploader uploader = client.createUpload(upload);
 
         assertEquals(uploader.getUploadURL(), new URL(mockServerURL + "/foo"));
+    }
+    
+    @Test
+    public void testRemoveFingerprintOnSuccessDisabled() throws IOException, ProtocolException {
+        
+        TusClient client = new TusClient();
+
+        TusURLStore store = new TusURLMemoryStore();
+        URL dummyURL = new URL("http://dummy-url/files/dummy");
+        store.set("fingerprint", dummyURL);
+        client.enableResuming(store);
+        
+        assertTrue(!client.removeFingerprintOnSuccessEnabled());
+
+        TusUpload upload = new TusUpload();
+        upload.setFingerprint("fingerprint");
+        
+        client.uploadFinished(upload);
+        
+        assertTrue(dummyURL.equals(store.get("fingerprint")));
+        
+    }
+    
+    @Test
+    public void testRemoveFingerprintOnSuccessEnabled() throws IOException, ProtocolException {
+        
+        TusClient client = new TusClient();
+
+        TusURLStore store = new TusURLMemoryStore();
+        URL dummyURL = new URL("http://dummy-url/files/dummy");
+        store.set("fingerprint", dummyURL);
+        client.enableResuming(store);
+        client.enableRemoveFingerprintOnSuccess();
+        
+        assertTrue(client.removeFingerprintOnSuccessEnabled());
+        
+        TusUpload upload = new TusUpload();
+        upload.setFingerprint("fingerprint");
+        
+        client.uploadFinished(upload);
+        
+        assertTrue(store.get("fingerprint") == null);
+        
     }
 }


### PR DESCRIPTION
This PR adds removeFingerprintOnSuccess config property to TusClient that allows to define whether  the upload URL should be removed from the URL store after a successful upload. 

This behaviour is disabled by default and should be enabled by calling:

```
TusClient.enableRemoveFingerprintOnSuccess()
``` 

Closes #26 issue

