### PR TITLE
Modify upload pausing

### DIFF
--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -271,6 +271,22 @@ public class TusUploader {
      * @throws IOException  Thrown if an exception occurs while cleaning up.
      */
     public void finish() throws ProtocolException, IOException {
+        finish(true);
+    }
+    
+    /**
+     * Finish the request by closing the HTTP connection. You can choose whether to close the Input Stream or not.
+     * You can call this method even before the entire file has been uploaded. Use this behavior to
+     * enable pausing uploads.
+     * Be aware it doesn't release local resources if you do not close the
+     * Input Stream: {@code closeStream == false}.
+     * To be safe use {@link TusUploader#finish()}.
+     * @param closeInputStream Determines whether the InputStream is closed with the HTTP connection. Not closing the
+     *                         Input Stream may be useful for future upload a future continuation of the upload.
+     * @throws ProtocolException Thrown if the server sends an unexpected status code
+     * @throws IOException  Thrown if an exception occurs while cleaning up.
+     */
+    public void finish(boolean closeInputStream) throws ProtocolException, IOException {   
         finishConnection();
         if (upload.getSize() == offset) {
             client.uploadFinished(upload);
@@ -278,30 +294,8 @@ public class TusUploader {
 
         // Close the TusInputStream after checking the response and closing the connection to ensure
         // that we will not need to read from it again in the future.
-        input.close();
-    }
-    
-    /**
-     * Finish the request by closing the HTTP connection. You can choose whether to close the Input Stream or not.
-     * You can call this method even before the entire file has been uploaded.
-     * It pauses the upload properly to be resumed in future.
-     * Be aware it doesn't release local resources as it does not close the File's
-     * Input Stream if {@code closeStream == false}
-     * To be safe use {@link TusUploader#finish()}.
-     * @param closeInputStream Determines whether the InputStream is closed with the HTTP connection. Not closing the
-     *                         Input Stream may be useful for future upload a future continuation of the upload.
-     * @throws ProtocolException Thrown if the server sends an unexpected status code
-     * @throws IOException  Thrown if an exception occurs while cleaning up.
-     */
-    public void finish(boolean closeInputStream) throws ProtocolException, IOException {
         if (closeInputStream){
-            finish();
-        } else {
-            finishConnection();
-            if (upload.getSize() == offset) {
-                client.uploadFinished(upload);
-            }
-            input.seekTo(0);
+        input.close();
         }
     }
 

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -261,23 +261,7 @@ public class TusUploader {
         return uploadURL;
     }
     
-     /**
-     * You can call this method even before the entire file has been uploaded.
-     * It pauses the upload properly to be resumed in future.
-     * Be aware it doesn't release local resources as it does not close the File's Input Stream.
-     * To be safe use {@link TusUploader#finish()}.
-     * @throws ProtocolException Thrown if the server sends an unexpected status
-     * code
-     * @throws IOException  Thrown if an exception occurs while cleaning up.
-     */
-    public void pause() throws ProtocolException, IOException {
-        finishConnection();
-        if (upload.getSize() == offset) {
-            client.uploadFinished(upload);
-        }
-       input.seekTo(0);
-    }
-
+   
 
     /**
      * Finish the request by closing the HTTP connection and the InputStream.
@@ -297,6 +281,30 @@ public class TusUploader {
         // Close the TusInputStream after checking the response and closing the connection to ensure
         // that we will not need to read from it again in the future.
         input.close();
+    }
+    
+    /**
+     * Finish the request by closing the HTTP connection. You can choose whether to close the Input Stream or not.
+     * You can call this method even before the entire file has been uploaded.
+     * It pauses the upload properly to be resumed in future.
+     * Be aware it doesn't release local resources as it does not close the File's
+     * Input Stream if {@code closeStream = false}
+     * To be safe use {@link TusUploader#finish()}.
+     * @param closeInputStream Determines whether the InputStream is closed with the HTTP connection. Not closing the
+     *                         Input Stream may be useful for future upload a future continuation of the upload.
+     * @throws ProtocolException Thrown if the server sends an unexpected status code
+     * @throws IOException  Thrown if an exception occurs while cleaning up.
+     */
+    public void finish(boolean closeInputStream) throws ProtocolException, IOException {
+        if (closeInputStream){
+            finish();
+        } else {
+            finishConnection();
+            if (upload.getSize() == offset) {
+                client.uploadFinished(upload);
+            }
+            input.seekTo(0);
+        }
     }
 
     private void finishConnection() throws ProtocolException, IOException {

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -265,6 +265,7 @@ public class TusUploader {
      * Finish the request by closing the HTTP connection and the InputStream.
      * You can call this method even before the entire file has been uploaded. Use this behavior to
      * enable pausing uploads.
+     * This method is equivalent to calling {@code finish(false)}.
      *
      * @throws ProtocolException Thrown if the server sends an unexpected status
      * code
@@ -275,12 +276,13 @@ public class TusUploader {
     }
     
     /**
-     * Finish the request by closing the HTTP connection. You can choose whether to close the Input Stream or not.
+     * Finish the request by closing the HTTP connection. You can choose whether to close the InputStream or not.
      * You can call this method even before the entire file has been uploaded. Use this behavior to
      * enable pausing uploads.
-     * Be aware it doesn't release local resources if you do not close the
-     * Input Stream: {@code closeStream == false}.
-     * To be safe use {@link TusUploader#finish()}.
+     * 
+     * Be aware that it doesn't automatically release local resources if {@code closeStream == false} and you do
+     * not close the InputStream on your own. To be safe use {@link TusUploader#finish()}.
+     *
      * @param closeInputStream Determines whether the InputStream is closed with the HTTP connection. Not closing the
      *                         Input Stream may be useful for future upload a future continuation of the upload.
      * @throws ProtocolException Thrown if the server sends an unexpected status code
@@ -294,8 +296,8 @@ public class TusUploader {
 
         // Close the TusInputStream after checking the response and closing the connection to ensure
         // that we will not need to read from it again in the future.
-        if (closeInputStream){
-        input.close();
+        if (closeInputStream) {
+            input.close();
         }
     }
 

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -260,6 +260,24 @@ public class TusUploader {
     public URL getUploadURL() {
         return uploadURL;
     }
+    
+     /**
+     * You can call this method even before the entire file has been uploaded.
+     * It pauses the upload properly to be resumed in future.
+     * Be aware it doesn't release local resources as it does not close the File's Input Stream.
+     * To be safe use {@link TusUploader#finish()}.
+     * @throws ProtocolException Thrown if the server sends an unexpected status
+     * code
+     * @throws IOException  Thrown if an exception occurs while cleaning up.
+     */
+    public void pause() throws ProtocolException, IOException {
+        finishConnection();
+        if (upload.getSize() == offset) {
+            client.uploadFinished(upload);
+        }
+       input.seekTo(0);
+    }
+
 
     /**
      * Finish the request by closing the HTTP connection and the InputStream.

--- a/src/main/java/io/tus/java/client/TusUploader.java
+++ b/src/main/java/io/tus/java/client/TusUploader.java
@@ -260,8 +260,6 @@ public class TusUploader {
     public URL getUploadURL() {
         return uploadURL;
     }
-    
-   
 
     /**
      * Finish the request by closing the HTTP connection and the InputStream.
@@ -288,7 +286,7 @@ public class TusUploader {
      * You can call this method even before the entire file has been uploaded.
      * It pauses the upload properly to be resumed in future.
      * Be aware it doesn't release local resources as it does not close the File's
-     * Input Stream if {@code closeStream = false}
+     * Input Stream if {@code closeStream == false}
      * To be safe use {@link TusUploader#finish()}.
      * @param closeInputStream Determines whether the InputStream is closed with the HTTP connection. Not closing the
      *                         Input Stream may be useful for future upload a future continuation of the upload.


### PR DESCRIPTION
This PR overloads the TusUploader#finish() method in order to provide a pausable upload, which doesn't close the underlying InputStream.