### PR TITLE
Removed unused package import of StandardCharset

### DIFF
--- a/src/main/java/io/tus/java/client/TusClient.java
+++ b/src/main/java/io/tus/java/client/TusClient.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**


### PR DESCRIPTION
- Since we are not using the package in TusClient.java, we can remove from the file.